### PR TITLE
removed non-existing constant in fav enemy perk hook

### DIFF
--- a/mod_sellswords/hooks/config/z_legends_fav_enemies.nut
+++ b/mod_sellswords/hooks/config/z_legends_fav_enemies.nut
@@ -249,7 +249,6 @@
 		case this.Const.EntityType.NoblePollax:
 		case this.Const.EntityType.NomadArcher:
 		case this.Const.EntityType.NomadOutlaw:
-		case this.Const.EntityType.OrcVanguard:
 		case this.Const.EntityType.SchratSmall:
 		case this.Const.EntityType.Sergeant:
 		case this.Const.EntityType.SkeletonLight:


### PR DESCRIPTION
pesky little bug in 8.2.7