### PR TITLE
mercenaries changes

### DIFF
--- a/mod_sellswords/hooks/entity/world/entity_manager.nut
+++ b/mod_sellswords/hooks/entity/world/entity_manager.nut
@@ -218,7 +218,7 @@
 			return;
 		}
 
-		// otherwise overwrite orignal logic
+		// otherwise overwrite original logic
 
 		local garbage = [];
 

--- a/mod_sellswords/hooks/entity/world/entity_manager.nut
+++ b/mod_sellswords/hooks/entity/world/entity_manager.nut
@@ -207,53 +207,212 @@
 	
 	q.manageAIFreeCompanies = @( __original ) function()
 	{
-		if (::Mod_Sellswords.EnableEnemySS)
+		// in case it's off, original logic should be used
+		if (!::Mod_Sellswords.EnableEnemySS) {
+			__original();
+			return;
+		}
+		// if location destroyed and it shouldn't spawn hostile mercenaries anymore, original logic should be used
+		if (!::Mod_Sellswords.KeepSpawningEnemySS && this.World.Flags.get("crss_camp_Defeated") == true) {
+			__original();
+			return;
+		}
+
+		// otherwise overwrite orignal logic
+
+		local garbage = [];
+
+		foreach( i, fc in this.m.FreeCompanies )
 		{
-		
-			local garbage = [];
-
-			foreach( i, fc in this.m.FreeCompanies )
+			if (fc.isNull() || !fc.isAlive())
 			{
-				if (fc.isNull() || !fc.isAlive())
+				garbage.push(i);
+			}
+		}
+
+		garbage.reverse();
+
+		foreach( g in garbage )
+		{
+			this.m.FreeCompanies.remove(g);
+		}
+
+		if (this.m.LastFreeCompanyUpdateTime + 3.0 > this.Time.getVirtualTimeF())
+		{
+			return;
+		}
+
+		this.m.LastFreeCompanyUpdateTime = this.Time.getVirtualTimeF();
+
+		local companies = 2;
+
+		if (companies == 0)
+		{
+			return;
+		}
+
+		if (this.m.FreeCompanies.len() < companies)
+		{
+			local playerTile = this.World.State.getPlayer().getTile();
+			local candidates = [];
+
+			foreach( s in this.World.EntityManager.getSettlements() )
+			{
+				if (s.isIsolated())
 				{
-					garbage.push(i);
+					continue;
 				}
+
+				if (s.getTile().getDistanceTo(playerTile) <= 10)
+				{
+					continue;
+				}
+
+				candidates.push(s);
 			}
 
-			garbage.reverse();
+			local start = candidates[this.Math.rand(0, candidates.len() - 1)];
+			local party = this.World.spawnEntity("scripts/entity/world/party", start.getTile().Coords);
+			party.setPos(this.createVec(party.getPos().X - 50, party.getPos().Y - 50));
+			local description = "A free company, out for their own share of crowns.";
+			party.setDescription(description);
+			local footprints = "Mercenaries";
+			party.setFootprintType(this.Const.World.FootprintsType.Mercenaries);
+			party.getFlags().set("IsFreeCompany", true);
+			party.setFaction(this.World.FactionManager.getFactionOfType(this.Const.FactionType.FreeCompany).getID());
 
-			foreach( g in garbage )
+			local ps = this.World.State.getPlayer().getStrength();
+			local days = this.World.getTime().Days;
+
+			if (days > 120)
 			{
-				this.m.FreeCompanies.remove(g);
+				ps = ps + 200;
+			}
+			else if (days > 90)
+			{
+				ps = ps + 100;
+			}
+			else if (days > 60)
+			{
+				ps = ps + 50;
 			}
 
-			if (this.m.LastFreeCompanyUpdateTime + 3.0 > this.Time.getVirtualTimeF())
+			local dc = this.Math.floor(days/60);
+			local r = this.Math.min(500 + this.World.getTime().Days, 200 + 2 * this.World.getTime().Days);
+			r = r * ::Mod_Sellswords.SellswordStrengthMultiplier * 0.01;
+
+			this.Const.World.Common.assignTroops(party, this.Const.World.Spawn.BountyHunterChasers, this.Math.rand(r * 0.8, r * 1.2));
+
+			party.getLoot().Money = this.Math.rand(300, 600);
+			party.getLoot().ArmorParts = this.Math.rand(0, 25);
+			party.getLoot().Medicine = this.Math.rand(0, 10);
+			party.getLoot().Ammo = this.Math.rand(0, 50);
+
+			for( local i = 0; i < 3; ++i )
 			{
-				return;
+				local loot = [
+					"supplies/bread_item",
+					"supplies/mead_item",
+					"supplies/dried_fruits_item",
+					"supplies/beer_item",
+					"loot/silver_bowl_item",
+					"loot/jeweled_crown_item",
+					"loot/ancient_amber_item",
+					"loot/webbed_valuables_item",
+					"loot/looted_valuables_item",
+					"loot/white_pearls_item",
+					"loot/rainbow_scale_item",
+					"loot/lindwurm_hoard_item",
+					"loot/silverware_item"
+				];
+				party.addToInventory(loot[this.Math.rand(0, loot.len() - 1)]);
 			}
 
-			this.m.LastFreeCompanyUpdateTime = this.Time.getVirtualTimeF();
-			
-			local companies = 2;
+			party.getSprite("base").setBrush("world_base_07");
+			party.getSprite("body").setBrush("figure_mercenary_0" + this.Math.rand(1, 2));
 
-			if (companies == 0)
+			while (true)
 			{
-				return;
+				local name = this.Const.Strings.MercenaryCompanyNames[this.Math.rand(0, this.Const.Strings.MercenaryCompanyNames.len() - 1)];
+
+				if (name == this.World.Assets.getName())
+				{
+					continue;
+				}
+
+				local abort = false;
+
+				foreach( p in this.m.FreeCompanies )
+				{
+					if (p.getName() == name)
+					{
+						abort = true;
+						break;
+					}
+				}
+
+				if (abort)
+				{
+					continue;
+				}
+
+				party.setName(name);
+				break;
 			}
 
-			if (this.m.FreeCompanies.len() < companies)
+			while (true)
 			{
-				local playerTile = this.World.State.getPlayer().getTile();
+				local banner = this.Const.PlayerBanners[this.Math.rand(0, this.Const.PlayerBanners.len() - 1)];
+
+				if (banner == this.World.Assets.getBanner())
+				{
+					continue;
+				}
+
+				local abort = false;
+
+				foreach( p in this.m.FreeCompanies )
+				{
+					if (p.getBanner() == banner)
+					{
+						abort = true;
+						break;
+					}
+				}
+
+				if (abort)
+				{
+					continue;
+				}
+
+				party.getSprite("banner").setBrush(banner);
+				break;
+			}
+
+			this.m.FreeCompanies.push(this.WeakTableRef(party));
+		}
+
+		foreach( fc in this.m.FreeCompanies )
+		{
+			fc.updatePlayerRelation();
+
+			if (!fc.getController().hasOrders())
+			{
 				local candidates = [];
 
-				foreach( s in this.World.EntityManager.getSettlements() )
+				foreach( s in this.m.Settlements )
 				{
-					if (s.isIsolated())
+					if (!s.isAlive() || s.isIsolated())
 					{
 						continue;
 					}
 
-					if (s.getTile().getDistanceTo(playerTile) <= 10)
+					if (!s.isAlliedWith(fc))
+					{
+						continue;
+					}
+
+					if (s.getTile().ID == fc.getTile().ID)
 					{
 						continue;
 					}
@@ -261,176 +420,26 @@
 					candidates.push(s);
 				}
 
-				local start = candidates[this.Math.rand(0, candidates.len() - 1)];
-				local party = this.World.spawnEntity("scripts/entity/world/party", start.getTile().Coords);
-				party.setPos(this.createVec(party.getPos().X - 50, party.getPos().Y - 50));
-				local description = "A free company, out for their own share of crowns.";
-				party.setDescription(description);
-				local footprints = "Mercenaries";
-				party.setFootprintType(this.Const.World.FootprintsType.Mercenaries);
-				party.getFlags().set("IsFreeCompany", true);
-				party.setFaction(this.World.FactionManager.getFactionOfType(this.Const.FactionType.FreeCompany).getID());
-				
-				local ps = this.World.State.getPlayer().getStrength();
-				local days = this.World.getTime().Days;
-				
-				if (days > 120)
+				if (candidates.len() == 0)
 				{
-					ps = ps + 200;
-				}
-				else if (days > 90)
-				{
-					ps = ps + 100;
-				}
-				else if (days > 60)
-				{
-					ps = ps + 50;
-				}
-				
-				local dc = this.Math.floor(days/60);
-				local r = this.Math.min(500 + this.World.getTime().Days, 200 + 2 * this.World.getTime().Days);
-				r = r * ::Mod_Sellswords.SellswordStrengthMultiplier * 0.01;
-				
-				this.Const.World.Common.assignTroops(party, this.Const.World.Spawn.BountyHunterChasers, this.Math.rand(r * 0.8, r * 1.2));
-
-				party.getLoot().Money = this.Math.rand(300, 600);
-				party.getLoot().ArmorParts = this.Math.rand(0, 25);
-				party.getLoot().Medicine = this.Math.rand(0, 10);
-				party.getLoot().Ammo = this.Math.rand(0, 50);
-
-				for( local i = 0; i < 3; ++i )
-				{
-					local loot = [
-						"supplies/bread_item",
-						"supplies/mead_item",
-						"supplies/dried_fruits_item",
-						"supplies/beer_item",
-						"loot/silver_bowl_item",
-						"loot/jeweled_crown_item",
-						"loot/ancient_amber_item",
-						"loot/webbed_valuables_item",
-						"loot/looted_valuables_item",
-						"loot/white_pearls_item",
-						"loot/rainbow_scale_item",
-						"loot/lindwurm_hoard_item",
-						"loot/silverware_item"
-					];
-					party.addToInventory(loot[this.Math.rand(0, loot.len() - 1)]);
+					continue;
 				}
 
-				party.getSprite("base").setBrush("world_base_07");
-				party.getSprite("body").setBrush("figure_mercenary_0" + this.Math.rand(1, 2));
-
-				while (true)
-				{
-					local name = this.Const.Strings.MercenaryCompanyNames[this.Math.rand(0, this.Const.Strings.MercenaryCompanyNames.len() - 1)];
-
-					if (name == this.World.Assets.getName())
-					{
-						continue;
-					}
-
-					local abort = false;
-
-					foreach( p in this.m.FreeCompanies )
-					{
-						if (p.getName() == name)
-						{
-							abort = true;
-							break;
-						}
-					}
-
-					if (abort)
-					{
-						continue;
-					}
-
-					party.setName(name);
-					break;
-				}
-
-				while (true)
-				{
-					local banner = this.Const.PlayerBanners[this.Math.rand(0, this.Const.PlayerBanners.len() - 1)];
-
-					if (banner == this.World.Assets.getBanner())
-					{
-						continue;
-					}
-
-					local abort = false;
-
-					foreach( p in this.m.FreeCompanies )
-					{
-						if (p.getBanner() == banner)
-						{
-							abort = true;
-							break;
-						}
-					}
-
-					if (abort)
-					{
-						continue;
-					}
-
-					party.getSprite("banner").setBrush(banner);
-					break;
-				}
-
-				this.m.FreeCompanies.push(this.WeakTableRef(party));
-			}
-
-			foreach( fc in this.m.FreeCompanies )
-			{
-				fc.updatePlayerRelation();
-
-				if (!fc.getController().hasOrders())
-				{
-					local candidates = [];
-
-					foreach( s in this.m.Settlements )
-					{
-						if (!s.isAlive() || s.isIsolated())
-						{
-							continue;
-						}
-
-						if (!s.isAlliedWith(fc))
-						{
-							continue;
-						}
-
-						if (s.getTile().ID == fc.getTile().ID)
-						{
-							continue;
-						}
-
-						candidates.push(s);
-					}
-
-					if (candidates.len() == 0)
-					{
-						continue;
-					}
-
-					local dest = candidates[this.Math.rand(0, candidates.len() - 1)];
-					local c = fc.getController();
-					local wait1 = this.new("scripts/ai/world/orders/wait_order");
-					wait1.setTime(this.Math.rand(10, 60) * 1.0);
-					c.addOrder(wait1);
-					local move = this.new("scripts/ai/world/orders/move_order");
-					move.setDestination(dest.getTile());
-					move.setRoadsOnly(false);
-					c.addOrder(move);
-					local wait2 = this.new("scripts/ai/world/orders/wait_order");
-					wait2.setTime(this.Math.rand(10, 60) * 1.0);
-					c.addOrder(wait2);
-					local fco = this.new("scripts/ai/world/orders/free_company_order");
-					fco.setSettlement(dest);
-					c.addOrder(fco);
-				}
+				local dest = candidates[this.Math.rand(0, candidates.len() - 1)];
+				local c = fc.getController();
+				local wait1 = this.new("scripts/ai/world/orders/wait_order");
+				wait1.setTime(this.Math.rand(10, 60) * 1.0);
+				c.addOrder(wait1);
+				local move = this.new("scripts/ai/world/orders/move_order");
+				move.setDestination(dest.getTile());
+				move.setRoadsOnly(false);
+				c.addOrder(move);
+				local wait2 = this.new("scripts/ai/world/orders/wait_order");
+				wait2.setTime(this.Math.rand(10, 60) * 1.0);
+				c.addOrder(wait2);
+				local fco = this.new("scripts/ai/world/orders/free_company_order");
+				fco.setSettlement(dest);
+				c.addOrder(fco);
 			}
 		}
 	}

--- a/scripts/!mods_preload/mod_sellswords.nut
+++ b/scripts/!mods_preload/mod_sellswords.nut
@@ -3,6 +3,7 @@
 	Name = "Sellswords Updated",
 	Version = "8.3.0",
 	EnableEnemySS = true,
+	KeepSpawningEnemySS = false,
 	SellswordStrengthMultiplier = 100,
 	EnableHostileSequences = true,
 	SellswordsPerk = "Student"
@@ -35,13 +36,48 @@
 
 	// MSU config page
 	local page = ::Mod_Sellswords.Mod.ModSettings.addPage("General");
-	local settingEnableEnemySS = page.addBooleanSetting("EnableHostileSellswords", true, "Enable Hostile Sellswords", "When enabled, there will be roaming groups of hostile Sellsword companies, these parties will stop spawning once you defeat the Legendary Company Tower location.");
-	local settingSellswordStrengthMultiplier = page.addRangeSetting("SellswordStrengthMultiplier", 100, 10, 300, 10.0, "Sellsword Strength Multiplier %", "Affects the CR rating of the hostile SS faction, only affects new spawns, not existing parties.");
-	local settingEnableHostileSequences = page.addBooleanSetting("EnableHostileSequences", true, "Enable Hostile Sequences", "When enabled, enemies have a low chance to roll with Sequences. If they do, then they also have a chance to drop whichever one they obtain.");
-	local settingSellswordsPerk = page.addEnumSetting("SellswordsPerk", "Student", ["Back to Basics", "Backstabber", "Berserker", "Dodge", "Escape Artist", "Footwork", "Fortified Mind", "Mind Over Body", "Nine Lives", "Pathfinder", "Quick Hands", "Rotation", "Steel Brow", "Student", "Thrives in Chaos", "Underdog"], "Sellsword Scenario Perk", "Choose a company perk to be added when you recruit a bro for the Sellswords Scenario.\n\nStudent by default.");
+	local settingSellswordsEnable = page.addEnumSetting(
+		"SellswordsSpawn",
+		"Enabled until destroyed",
+		["Enabled", "Enabled until destroyed", "Disabled"],
+		"Enable hostile Sellswords",
+		"Enabled - there will be roaming groups of hostile Sellsword companies,\n\nEnabled until destroyed - there will be roaming groups of hostile Sellsword companies, but these parties will stop spawning once you defeat the Legendary Company Tower location,\n\nDisabled - standard non-hostile mercenary parties will spawn."
+	);
+	local settingSellswordStrengthMultiplier = page.addRangeSetting(
+		"SellswordStrengthMultiplier",
+		100, 10, 300, 10.0,
+		"Sellsword Strength Multiplier %",
+		"Affects the CR rating of the hostile SS faction, only affects new spawns, not existing parties."
+	);
+	page.addDivider("divider_sequences");
+	local settingEnableHostileSequences = page.addBooleanSetting(
+		"EnableHostileSequences",
+		true,
+		"Enable Hostile Sequences",
+		"When enabled, enemies have a low chance to roll with Sequences. If they do, then they also have a chance to drop whichever one they obtain."
+	);
+	page.addDivider("divider_perks");
+	local settingSellswordsPerk = page.addEnumSetting(
+		"SellswordsPerk",
+		"Student",
+		["Back to Basics", "Backstabber", "Berserker", "Dodge", "Escape Artist", "Footwork", "Fortified Mind", "Mind Over Body", "Nine Lives", "Pathfinder", "Quick Hands", "Rotation", "Steel Brow", "Student", "Thrives in Chaos", "Underdog"],
+		"Sellsword Scenario Perk",
+		"Choose a company perk to be added when you recruit a bro for the Sellswords Scenario.\n\nStudent by default."
+	);
 
 	// Settings for that config 
-	settingEnableEnemySS.addCallback(function(_value) { ::Mod_Sellswords.EnableEnemySS = _value; });
+	settingSellswordsEnable.addCallback(function(_value) {
+		if (_value == "Disabled") {
+			::Mod_Sellswords.EnableEnemySS = false;
+			::Mod_Sellswords.KeepSpawningEnemySS = false;
+		} else if (_value == "Enabled") {
+			::Mod_Sellswords.EnableEnemySS = true;
+			::Mod_Sellswords.KeepSpawningEnemySS = true;
+		} else {
+			::Mod_Sellswords.EnableEnemySS = true;
+			::Mod_Sellswords.KeepSpawningEnemySS = false;
+		}
+	});
 	settingSellswordStrengthMultiplier.addCallback(function(_value) { ::Mod_Sellswords.SellswordStrengthMultiplier = _value; });
 	settingEnableHostileSequences.addCallback(function(_value) { ::Mod_Sellswords.EnableHostileSequences = _value; });
 	settingSellswordsPerk.addCallback(function(_value) { ::Mod_Sellswords.SellswordsPerk = _value; });

--- a/scripts/entity/world/locations/crss_camp_location.nut
+++ b/scripts/entity/world/locations/crss_camp_location.nut
@@ -333,5 +333,9 @@ this.crss_camp_location <- this.inherit("scripts/entity/world/location", {
 		body.setBrush("legend_ranger_tower");
 	}
 
+	function onCombatLost() {
+		this.World.Flags.set("crss_camp_Defeated", true);
+	}
+
 });
 


### PR DESCRIPTION
- enabled for standard mercenary companies to spawn when disabled, as original function call was missing in manageAIFreeCompanies(),
- made mercenaries to actually stop spawning when location destroyed,
- changed corresponding checkbox setting to enum enabling players to choose which behavior they want,

note: there's not much changed in entity manager, it's just indentation and git being git, no changes below this comment: 
// otherwise overwrite original logic