### PR TITLE
Fixed dryad armor layers not regenerating on turn start

### DIFF
--- a/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_archer.nut
+++ b/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_archer.nut
@@ -45,7 +45,7 @@ this.dryad_pauldrons_archer <- this.inherit("scripts/items/legend_armor/legend_a
 		});
 		return result;
 	}
-	
+
 	function onArmorTooltip( _result )
 	{
 		_result.push({
@@ -55,28 +55,4 @@ this.dryad_pauldrons_archer <- this.inherit("scripts/items/legend_armor/legend_a
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });

--- a/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_grunt.nut
+++ b/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_grunt.nut
@@ -46,7 +46,7 @@ this.dryad_pauldrons_grunt <- this.inherit("scripts/items/legend_armor/legend_ar
 		return result;
 	}
 	
-	function onArmorTooltip( _result )
+function onArmorTooltip( _result )
 	{
 		_result.push({
 			id = 6,
@@ -55,28 +55,4 @@ this.dryad_pauldrons_grunt <- this.inherit("scripts/items/legend_armor/legend_ar
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });

--- a/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_shaman.nut
+++ b/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_shaman.nut
@@ -46,7 +46,7 @@ this.dryad_pauldrons_shaman <- this.inherit("scripts/items/legend_armor/legend_a
 		return result;
 	}
 	
-	function onArmorTooltip( _result )
+function onArmorTooltip( _result )
 	{
 		_result.push({
 			id = 6,
@@ -55,28 +55,4 @@ this.dryad_pauldrons_shaman <- this.inherit("scripts/items/legend_armor/legend_a
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });

--- a/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_tamer.nut
+++ b/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_tamer.nut
@@ -46,7 +46,7 @@ this.dryad_pauldrons_tamer <- this.inherit("scripts/items/legend_armor/legend_ar
 		return result;
 	}
 	
-	function onArmorTooltip( _result )
+function onArmorTooltip( _result )
 	{
 		_result.push({
 			id = 6,
@@ -55,28 +55,4 @@ this.dryad_pauldrons_tamer <- this.inherit("scripts/items/legend_armor/legend_ar
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });

--- a/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_warrior.nut
+++ b/scripts/items/legend_armor/armor_upgrades/dryad_pauldrons_warrior.nut
@@ -46,7 +46,7 @@ this.dryad_pauldrons_warrior <- this.inherit("scripts/items/legend_armor/legend_
 		return result;
 	}
 	
-	function onArmorTooltip( _result )
+function onArmorTooltip( _result )
 	{
 		_result.push({
 			id = 6,
@@ -55,28 +55,4 @@ this.dryad_pauldrons_warrior <- this.inherit("scripts/items/legend_armor/legend_
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });

--- a/scripts/items/legend_armor/chain/dryad_chain_archer.nut
+++ b/scripts/items/legend_armor/chain/dryad_chain_archer.nut
@@ -46,7 +46,7 @@ this.dryad_chain_archer <- this.inherit("scripts/items/legend_armor/legend_armor
 		return result;
 	}
 	
-	function onArmorTooltip( _result )
+function onArmorTooltip( _result )
 	{
 		_result.push({
 			id = 6,
@@ -55,29 +55,5 @@ this.dryad_chain_archer <- this.inherit("scripts/items/legend_armor/legend_armor
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/chain/dryad_chain_grunt.nut
+++ b/scripts/items/legend_armor/chain/dryad_chain_grunt.nut
@@ -55,29 +55,5 @@ this.dryad_chain_grunt <- this.inherit("scripts/items/legend_armor/legend_armor_
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/chain/dryad_chain_shaman.nut
+++ b/scripts/items/legend_armor/chain/dryad_chain_shaman.nut
@@ -55,29 +55,5 @@ this.dryad_chain_shaman <- this.inherit("scripts/items/legend_armor/legend_armor
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/chain/dryad_chain_tamer.nut
+++ b/scripts/items/legend_armor/chain/dryad_chain_tamer.nut
@@ -55,29 +55,5 @@ this.dryad_chain_tamer <- this.inherit("scripts/items/legend_armor/legend_armor_
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/chain/dryad_chain_warrior.nut
+++ b/scripts/items/legend_armor/chain/dryad_chain_warrior.nut
@@ -55,29 +55,5 @@ this.dryad_chain_warrior <- this.inherit("scripts/items/legend_armor/legend_armo
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/cloak/dryad_cloak_archer.nut
+++ b/scripts/items/legend_armor/cloak/dryad_cloak_archer.nut
@@ -54,29 +54,5 @@ this.dryad_cloak_archer <- this.inherit("scripts/items/legend_armor/legend_armor
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/cloak/dryad_cloak_grunt.nut
+++ b/scripts/items/legend_armor/cloak/dryad_cloak_grunt.nut
@@ -54,29 +54,5 @@ this.dryad_cloak_grunt <- this.inherit("scripts/items/legend_armor/legend_armor_
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/cloak/dryad_cloak_shaman.nut
+++ b/scripts/items/legend_armor/cloak/dryad_cloak_shaman.nut
@@ -54,29 +54,5 @@ this.dryad_cloak_shaman <- this.inherit("scripts/items/legend_armor/legend_armor
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/cloak/dryad_cloak_tamer.nut
+++ b/scripts/items/legend_armor/cloak/dryad_cloak_tamer.nut
@@ -54,29 +54,4 @@ this.dryad_cloak_tamer <- this.inherit("scripts/items/legend_armor/legend_armor_
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
-

--- a/scripts/items/legend_armor/cloak/dryad_cloak_warrior.nut
+++ b/scripts/items/legend_armor/cloak/dryad_cloak_warrior.nut
@@ -54,29 +54,5 @@ this.dryad_cloak_warrior <- this.inherit("scripts/items/legend_armor/legend_armo
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/plate/dryad_plate_archer.nut
+++ b/scripts/items/legend_armor/plate/dryad_plate_archer.nut
@@ -45,7 +45,7 @@ this.dryad_plate_archer <- this.inherit("scripts/items/legend_armor/legend_armor
 		});
 		return result;
 	}
-	
+
 	function onArmorTooltip( _result )
 	{
 		_result.push({
@@ -55,29 +55,5 @@ this.dryad_plate_archer <- this.inherit("scripts/items/legend_armor/legend_armor
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 

--- a/scripts/items/legend_armor/plate/dryad_plate_grunt.nut
+++ b/scripts/items/legend_armor/plate/dryad_plate_grunt.nut
@@ -45,7 +45,7 @@ this.dryad_plate_grunt <- this.inherit("scripts/items/legend_armor/legend_armor_
 		});
 		return result;
 	}
-	
+
 	function onArmorTooltip( _result )
 	{
 		_result.push({
@@ -54,30 +54,6 @@ this.dryad_plate_grunt <- this.inherit("scripts/items/legend_armor/legend_armor_
 			icon = "ui/icons/repair_item.png",
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
-	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
+	}	
 });
 

--- a/scripts/items/legend_armor/plate/dryad_plate_shaman.nut
+++ b/scripts/items/legend_armor/plate/dryad_plate_shaman.nut
@@ -45,7 +45,7 @@ this.dryad_plate_shaman <- this.inherit("scripts/items/legend_armor/legend_armor
 		});
 		return result;
 	}
-	
+
 	function onArmorTooltip( _result )
 	{
 		_result.push({
@@ -54,30 +54,6 @@ this.dryad_plate_shaman <- this.inherit("scripts/items/legend_armor/legend_armor
 			icon = "ui/icons/repair_item.png",
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
-	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
+	}	
 });
 

--- a/scripts/items/legend_armor/plate/dryad_plate_tamer.nut
+++ b/scripts/items/legend_armor/plate/dryad_plate_tamer.nut
@@ -45,7 +45,7 @@ this.dryad_plate_tamer <- this.inherit("scripts/items/legend_armor/legend_armor_
 		});
 		return result;
 	}
-	
+
 	function onArmorTooltip( _result )
 	{
 		_result.push({
@@ -54,30 +54,6 @@ this.dryad_plate_tamer <- this.inherit("scripts/items/legend_armor/legend_armor_
 			icon = "ui/icons/repair_item.png",
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
-	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
+	}	
 });
 

--- a/scripts/items/legend_armor/plate/dryad_plate_warrior.nut
+++ b/scripts/items/legend_armor/plate/dryad_plate_warrior.nut
@@ -45,7 +45,7 @@ this.dryad_plate_warrior <- this.inherit("scripts/items/legend_armor/legend_armo
 		});
 		return result;
 	}
-	
+
 	function onArmorTooltip( _result )
 	{
 		_result.push({
@@ -55,29 +55,5 @@ this.dryad_plate_warrior <- this.inherit("scripts/items/legend_armor/legend_armo
 			text = "Repairs [color=" + this.Const.UI.Color.PositiveValue + "]5[/color] armour each turn"
 		});
 	}
-
-	function onTurnStart()
-	{
-		local actor = this.getContainer().getActor();
-		local body = actor.getItems().getItemAtSlot(this.Const.ItemSlot.Body);
-		local bodyMissing = body.getArmorMax() - body.getArmor();
-		local bodyAdded = this.Math.min(bodyMissing, 5);
-
-		if (bodyAdded <= 0)
-		{
-			return;
-		}
-
-		body.setArmor(body.getArmor() + bodyAdded);
-		actor.setDirty(true);
-
-		if (!actor.isHiddenToPlayer())
-		{
-			this.Tactical.spawnIconEffect("status_effect_79", actor.getTile(), this.Const.Tactical.Settings.SkillIconOffsetX, this.Const.Tactical.Settings.SkillIconOffsetY, this.Const.Tactical.Settings.SkillIconScale, this.Const.Tactical.Settings.SkillIconFadeInDuration, this.Const.Tactical.Settings.SkillIconStayDuration, this.Const.Tactical.Settings.SkillIconFadeOutDuration, this.Const.Tactical.Settings.SkillIconMovement);
-			this.Sound.play("sounds/enemies/dlc2/schrat_idle_05.wav", this.Const.Sound.Volume.RacialEffect * 2.0, actor.getPos());
-			this.Tactical.EventLog.log(this.Const.UI.getColorized(this.m.Name, "#1e468f") + " repaired for " + bodyAdded + " points");
-		}
-	}
-	
 });
 


### PR DESCRIPTION
Only the base armor layer was regenerating, because other armor upgrades do not have "**onTurnStart**" called on them. To implement the regen, I made the `dryad_cloth ` armor look at its layers and apply the following logic:

Only layers with "dryad" in ID are counted.
Each counted layer is checked whether it is damaged. Damaged layers are contributing 5 or less regen to fix the layer.

 - Tested this in battle - regen works as expected.
 - Non-dryad cloth base layers do not regenerate, even if have dryad upgrade layers. On dryad cloth, if only non-dryad layers are damaged, there is no regeneration. Armor regen intensifies and is at maximum value when all dryad layers are damaged.  
 - "Destroyed" armor is regenerated. (Did not test the end of combat).

Based on the "addArmor" logic, it will still repair non-dryad layers from the bottom up if they are below a damaged dryad layer.

![image](https://github.com/user-attachments/assets/e299da87-f3b9-41c9-8b92-63ce80569ab2)
