### PR TITLE
Fixed smackdown not applying AP debuff

### DIFF
--- a/mod_sellswords/hooks/skills/effects/legend_knockback_prepared_effect.nut
+++ b/mod_sellswords/hooks/skills/effects/legend_knockback_prepared_effect.nut
@@ -4,16 +4,21 @@
 	{
 		--this.m.AttacksLeft;
 		if (this.m.AttacksLeft <= 0)
+		{
 			this.removeSelf();
-
-		if (_skill != this)
-			return;
+		}
 
 		if (!_targetEntity.isAlive())
+		{
 			return;
+		}
 
-		_targetEntity.getSkills().getSkillByID("effects.legend_baffled");
-		_targetEntity.getSkills().getSkillByID("effects.cr_smackdown");
+		// refresh the effects
+		_targetEntity.getSkills().removeByID("effects.legend_baffled");
+		_targetEntity.getSkills().removeByID("effects.cr_smackdown");
+
+		_targetEntity.getSkills().add(this.new("scripts/skills/effects/legend_baffled_effect"));
+		_targetEntity.getSkills().add(this.new("scripts/skills/effects/cr_smackdown_effect"));
 	}
 
 });

--- a/scripts/skills/effects/cr_smackdown_effect.nut
+++ b/scripts/skills/effects/cr_smackdown_effect.nut
@@ -5,7 +5,7 @@ this.cr_smackdown_effect <- this.inherit("scripts/skills/skill", {
 	function create()
 	{
 		this.m.ID = "effects.cr_smackdown";
-		this.m.Name = "Rattled";
+		this.m.Name = "Smacked Down";
 		this.m.Icon = "ui/perks/legend_vala_trance_mastery.png";
 		this.m.IconMini = "crSmackdown_mini";
 		this.m.Type = this.Const.SkillType.StatusEffect;


### PR DESCRIPTION
The skill was not applying effects described in description. I fixed a couple bugs - first the skill was never passing the `_skill != this` check and was not executing code, and then it was not adding the expected effects.

Verified fix applies baffled, as well as the base knockback effect.
Also changed the status effect icon name from "Rattled" to "Smacked Down".

![image](https://github.com/user-attachments/assets/b2864ec5-0873-4c93-8f13-a1f54b956035)
