### PR TITLE
Update crGoblinwarrior.nut

### DIFF
--- a/scripts/entity/tactical/enemies/crGoblinwarrior.nut
+++ b/scripts/entity/tactical/enemies/crGoblinwarrior.nut
@@ -22,7 +22,8 @@ this.crGoblinwarrior <- this.inherit("scripts/entity/tactical/goblin", {
 		this.m.CurrentProperties = clone b;
 		this.m.ActionPointCosts = this.Const.DefaultMovementAPCost;
 		this.m.FatigueCosts = this.Const.DefaultMovementFatigueCost;
-		this.getSprite("head").setBrush("head_kobold_0" + this.Math.rand(1, 5));			
+		// this.getSprite("head").setBrush("head_kobold_0" + this.Math.rand(1, 5));		
+		this.getSprite("head").setBrush("bust_goblin_01_head_0" + this.Math.rand(1, 3));			
 		this.addDefaultStatusSprites();
 		local parts = [
 			"body", "tattoo_body", "injury_body",


### PR DESCRIPTION
Commented out a reference in the Goblin Warrior script (crGoblinwarrior.nut) to removed Kobold assets (the head), and replaced it with a reference to Goblin Rider (crGoblinRider00.nut) assets.

Before this edit, the reference to kobold assets was causing crashes whenever a Goblin Warrior was killed in combat, or freeze the game's turn order if they died at the end of their turn due to a DoT effect (bleed/poison).