### PR TITLE
more fixes and modernizing

### DIFF
--- a/mod_sellswords/config/strings.nut
+++ b/mod_sellswords/config/strings.nut
@@ -60,6 +60,8 @@ Master the art of movement!
 
 [color=%passive%][u]Passive:[/u][/color]
 • Reduce the Action Point cost of [color=%skill%]Rotation[/color], [color=%skill%]Footwork[/color], [color=%skill%]Evasion[/color], [color=%skill%]Sprint[/color], [color=%skill%]Climb[/color], and [color=%skill%]Audacious Charge[/color] by [color=%negative%]1[/color] and reduce Fatigue costs by [color=%negative%]50%[/color]
+
+• Does not stack with [color=%perk%]Freedom of Movement[/color].
 ";
 
 ::Const.Strings.PerkName.crGrandslam <- "Grand Slam";

--- a/mod_sellswords/config/z_background_perks.nut
+++ b/mod_sellswords/config/z_background_perks.nut
@@ -160,7 +160,7 @@ setupBackground("scripts/skills/backgrounds/legend_muladi_background", ["scripts
 	
 setupBackground("scripts/skills/backgrounds/legend_nightwatch_background", ["scripts/skills/perks/perk_legend_night_raider"], [{def = ::Legends.Perk.LegendNightRaider, level = 0, optional = false}]);
 	
-setupBackground("scripts/skills/backgrounds/legend_noble_2h", ["scripts/skills/perks/perk_legend_forceful_swing"], [{def = ::Legends.Perk.LegendForcefulSwing, level = 0, optional = false}]);
+setupBackground("scripts/skills/backgrounds/legend_noble_2h", ["scripts/skills/perks/perk_legend_bloody_harvest"], [{def = ::Legends.Perk.LegendBloodyHarvest, level = 0, optional = false}]);
 	
 setupBackground("scripts/skills/backgrounds/legend_noble_background", ["scripts/skills/perks/perk_legend_assured_conquest"], [{def = ::Legends.Perk.LegendAssuredConquest, level = 0, optional = false}]);
 	
@@ -210,10 +210,7 @@ setupBackground("scripts/skills/backgrounds/miller_background", ["scripts/skills
 
 setupBackground("scripts/skills/backgrounds/miner_background", ["scripts/skills/perks/perk_legend_specialist_miner"], [{def = ::Legends.Perk.LegendSpecialistMiner, level = 0, optional = false}]);
 
-if (::mods_getRegisteredMod("mod_specialist_skills_rework") != null)
-	setupBackground("scripts/skills/backgrounds/minstrel_background", ["scripts/skills/perks/perk_legend_daze"], [{def = ::Legends.Perk.LegendDaze, level = 0, optional = false}]);
-else
-	setupBackground("scripts/skills/backgrounds/minstrel_background", ["scripts/skills/perks/perk_legend_minnesanger"], [{def = ::Legends.Perk.LegendMinnesanger, level = 0, optional = false}]);
+setupBackground("scripts/skills/backgrounds/minstrel_background", ["scripts/skills/perks/perk_legend_minnesanger"], [{def = ::Legends.Perk.LegendMinnesanger, level = 0, optional = false}]);
 
 setupBackground("scripts/skills/backgrounds/monk_background", ["scripts/skills/perks/perk_legend_holyflame"], [{def = ::Legends.Perk.LegendHolyFlame, level = 0, optional = false}]);
 

--- a/mod_sellswords/hooks/config/strings.nut
+++ b/mod_sellswords/hooks/config/strings.nut
@@ -73,6 +73,20 @@ Master the movements required to spin your staff in a great flourish so that it 
 
 ::Const.Perks.PerkDefObjects[::Legends.Perk.LegendSpecStaffStun].Tooltip = ::Const.Strings.PerkDescription.LegendSpecStaffStun;
 
+::Const.Strings.PerkDescription.LegendFreedomOfMovement = @"
+A skilled mercenary has unimpeded movement regardless of armor.
+
+[color=%passive%][u]Passive:[/u][/color]
+• Reduces Fatigue cost of [color=%skill%]Climb[/color], [color=%skill%]Lunge[/color], [color=%skill%]Footwork[/color], [color=%skill%]Rotation[/color], [color=%skill%]Leap[/color], [color=%skill%]Quick Step[/color], [color=%skill%]Evasion[/color], [color=%skill%]Tumble[/color] and [color=%skill%]Audacious Charge[/color] by [color=%negative%]50%[/color].
+
+• The Action Point cost of [color=%skill%]Audacious Charge[/color], [color=%skill%]Climb[/color], [color=%skill%]Footwork[/color] and [color=%skill%]Rotation[/color] is reduced by [color=%negative%]1[/color], [color=%skill%]Leap[/color] by [color=%negative%]3[/color] and [color=%skill%]Evasion[/color] by [color=%negative%]2[/color].
+
+• Picking this perk will also add [color=%perk%]Tactical Maneuvers[/color] and [color=%perk%]Quick Step[/color] to your perk tree.
+
+• This is an upgraded version of [color=%perk%]Furinkazan[/color] and is not stackable.
+";
+::Const.Perks.PerkDefObjects[::Legends.Perk.LegendFreedomOfMovement].Tooltip = ::Const.Strings.PerkDescription.LegendFreedomOfMovement;
+
 ::Const.Strings.PerkDescription.LegendLastStand = @"
 'This is the hill that you will NOT die on!'
 

--- a/mod_sellswords/hooks/scenarios/world/legends_noble_scenario.nut
+++ b/mod_sellswords/hooks/scenarios/world/legends_noble_scenario.nut
@@ -29,7 +29,6 @@
 		talents[this.Const.Attributes.MeleeDefense] = 1;
 		talents[this.Const.Attributes.Fatigue] = 1;	
 		talents[this.Const.Attributes.Bravery] = 2;				
-		this.addScenarioPerk(bros[0].getBackground(), this.Const.Perks.PerkDefs.Rotation);
 		this.addScenarioPerk(bros[0].getBackground(), this.Const.Perks.PerkDefs.RallyTheTroops);
 		bros[0].getSkills().add(this.new("scripts/skills/traits/drunkard_trait"));
 		bros[0].getSkills().add(this.new("scripts/skills/traits/legend_noble_killer_trait"));
@@ -63,7 +62,6 @@
 		bros[1].getSkills().add(this.new("scripts/skills/traits/optimist_trait"));
 		bros[1].getSkills().add(this.new("scripts/skills/traits/determined_trait"));
 		bros[1].getSkills().add(this.new("scripts/skills/traits/greedy_trait"));
-		this.addScenarioPerk(bros[1].getBackground(), this.Const.Perks.PerkDefs.Rotation);
 		bros[1].setPlaceInFormation(3);
 		//bros[1].setVeteranPerks(2);
 		bros[2].setStartValuesEx([
@@ -81,7 +79,6 @@
 		bros[2].getSkills().add(this.new("scripts/skills/traits/huge_trait"));
 		bros[2].getSkills().add(this.new("scripts/skills/traits/fat_trait"));
 		bros[2].getSkills().add(this.new("scripts/skills/traits/gluttonous_trait"));
-		this.addScenarioPerk(bros[2].getBackground(), this.Const.Perks.PerkDefs.Rotation);
 		bros[2].setPlaceInFormation(4);
 		//bros[2].setVeteranPerks(2);
 		bros[3].setStartValuesEx([
@@ -113,7 +110,6 @@
 		bros[3].getSkills().add(this.new("scripts/skills/traits/legend_pragmatic_trait"));
 		bros[3].getSkills().add(this.new("scripts/skills/traits/loyal_trait"));
 		bros[3].getSkills().add(this.new("scripts/skills/traits/legend_slack_trait"));
-		this.addScenarioPerk(bros[3].getBackground(), this.Const.Perks.PerkDefs.Rotation);
 		bros[3].setPlaceInFormation(5);
 		//bros[3].setVeteranPerks(2);
 		bros[4].setStartValuesEx([
@@ -131,7 +127,6 @@
 		bros[4].getSkills().add(this.new("scripts/skills/traits/loyal_trait"));
 		bros[4].getSkills().add(this.new("scripts/skills/traits/lucky_trait"));
 		bros[4].getSkills().add(this.new("scripts/skills/traits/survivor_trait"));
-		this.addScenarioPerk(bros[4].getBackground(), this.Const.Perks.PerkDefs.Rotation);
 		bros[4].setPlaceInFormation(12);
 		//bros[4].setVeteranPerks(2);
 		local items = bros[4].getItems();
@@ -163,7 +158,6 @@
 		bros[5].getSkills().add(this.new("scripts/skills/traits/legend_sureshot_trait"));
 		bros[5].getSkills().add(this.new("scripts/skills/traits/teamplayer_trait"));
 		bros[5].getSkills().add(this.new("scripts/skills/traits/legend_predictable_trait"));
-		this.addScenarioPerk(bros[5].getBackground(), this.Const.Perks.PerkDefs.Rotation);
 
 		if (bros[5].getBaseProperties().RangedSkill <= 60)
 		{

--- a/mod_sellswords/hooks/skills/actives/footwork.nut
+++ b/mod_sellswords/hooks/skills/actives/footwork.nut
@@ -6,7 +6,7 @@
 		local fat = this.getContainer().getActor().getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]) * -1;
 		this.m.FatigueCost = ::Math.min(20, this.m.FatigueCost + fat);
 		
-		local frkz = this.getContainer().hasSkill("perk.crFurinkazan");
+		local frkz = this.getContainer().hasSkill("perk.crFurinkazan") && !this.getContainer().hasSkill("perk.legend_freedom_of_movement");
 		this.m.FatigueCostMult = _properties.IsFleetfooted || frkz ? 0.5 : 1.0;
 
 		if (this.getContainer().getActor().getSkills().hasSkill("effects.goblin_grunt_potion") || frkz)

--- a/mod_sellswords/hooks/skills/actives/legend_climb_skill.nut
+++ b/mod_sellswords/hooks/skills/actives/legend_climb_skill.nut
@@ -2,7 +2,7 @@
 
 	q.onAfterUpdate = @( __original ) function ( _properties )
 	{		
-		local frkz = this.getContainer().hasSkill("perk.crFurinkazan");
+		local frkz = this.getContainer().hasSkill("perk.crFurinkazan") && !this.getContainer().hasSkill("perk.legend_freedom_of_movement");
 		this.m.FatigueCostMult = _properties.IsFleetfooted || frkz ? 0.5 : 1.0;
 
 		if (this.getContainer().getActor().getSkills().hasSkill("perk.legend_backflip"))

--- a/mod_sellswords/hooks/skills/actives/legend_evasion_skill.nut
+++ b/mod_sellswords/hooks/skills/actives/legend_evasion_skill.nut
@@ -10,7 +10,7 @@
 
 	q.onAfterUpdate <- function ( _properties )
 	{
-		local frkz = this.getContainer().hasSkill("perk.crFurinkazan");
+		local frkz = this.getContainer().hasSkill("perk.crFurinkazan") && !this.getContainer().hasSkill("perk.legend_freedom_of_movement");
 		this.m.FatigueCostMult = _properties.IsFleetfooted || frkz ? 0.5 : 1.0;
 
 		if (this.getContainer().getActor().getSkills().hasSkill("effects.goblin_grunt_potion") || frkz)

--- a/mod_sellswords/hooks/skills/actives/legend_leap_skill.nut
+++ b/mod_sellswords/hooks/skills/actives/legend_leap_skill.nut
@@ -25,10 +25,5 @@
 
 			bg.addPerk(_perk, _row);
 		};
-
-		if (!this.getContainer().hasSkill("perk.legend_tumble"))
-		{
-			addPerk(this.Const.Perks.PerkDefs.LegendTumble, 6);				
-		}
 	};
 });

--- a/mod_sellswords/hooks/skills/actives/legend_sprint_skill_3.nut
+++ b/mod_sellswords/hooks/skills/actives/legend_sprint_skill_3.nut
@@ -17,7 +17,7 @@
 	{
 		local fat = this.getContainer().getActor().getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]) * -1;
 		this.m.FatigueCost = ::Math.min(22, this.m.FatigueCost + fat);	
-		local frkz = this.getContainer().hasSkill("perk.crFurinkazan");
+		local frkz = this.getContainer().hasSkill("perk.crFurinkazan") && !this.getContainer().hasSkill("perk.legend_freedom_of_movement");
 		this.m.FatigueCostMult = _properties.IsFleetfooted || frkz ? 0.5 : 1.0;
 
 		if (this.getContainer().getActor().getSkills().hasSkill("effects.goblin_grunt_potion") || frkz)

--- a/mod_sellswords/hooks/skills/actives/legend_sprint_skill_5.nut
+++ b/mod_sellswords/hooks/skills/actives/legend_sprint_skill_5.nut
@@ -10,7 +10,7 @@
 	{
 		local fat = this.getContainer().getActor().getItems().getStaminaModifier([::Const.ItemSlot.Body, ::Const.ItemSlot.Head]) * -1;
 		this.m.FatigueCost = ::Math.min(26, this.m.FatigueCost + fat);		
-		local frkz = this.getContainer().hasSkill("perk.crFurinkazan");
+		local frkz = this.getContainer().hasSkill("perk.crFurinkazan") && !this.getContainer().hasSkill("perk.legend_freedom_of_movement");
 		this.m.FatigueCostMult = _properties.IsFleetfooted || frkz ? 0.5 : 1.0;
 
 		if (this.getContainer().getActor().getSkills().hasSkill("effects.goblin_grunt_potion") || frkz)

--- a/mod_sellswords/hooks/skills/actives/rotation.nut
+++ b/mod_sellswords/hooks/skills/actives/rotation.nut
@@ -2,7 +2,7 @@
 
 	q.onAfterUpdate = @( __original ) function ( _properties )
 	{
-		local frkz = this.getContainer().hasSkill("perk.crFurinkazan");
+		local frkz = this.getContainer().hasSkill("perk.crFurinkazan") && !this.getContainer().hasSkill("perk.legend_freedom_of_movement");
 		this.m.FatigueCostMult = _properties.IsFleetfooted || frkz ? 0.5 : 1.0;
 
 		if (this.getContainer().getActor().getSkills().hasSkill("effects.goblin_grunt_potion") || frkz)

--- a/mod_sellswords/hooks/skills/special/double_grip.nut
+++ b/mod_sellswords/hooks/skills/special/double_grip.nut
@@ -13,7 +13,7 @@
 				id = 11,
 				type = "text",
 				icon = "ui/icons/regular_damage.png",
-				text = "+[color=%positive%]" + cof + "%[/color] Damage"
+				text = "+[color=%positive%]" + cof + "%[/color] Damage due to Grand Slam"
 			});
 		}
 		return ret;
@@ -21,6 +21,8 @@
 
 	q.onUpdate = @(__original) function ( _properties )
 	{
+		__original(_properties); //??
+
 		if (this.canDoubleGrip())
 		{
 			local cof = 1.0;

--- a/scripts/skills/actives/zcr_charge.nut
+++ b/scripts/skills/actives/zcr_charge.nut
@@ -289,7 +289,7 @@ this.zcr_charge <- this.inherit("scripts/skills/skill", {
 
 	function onAfterUpdate( _properties )
 	{
-		local frkz = this.getContainer().hasSkill("perk.crFurinkazan");
+		local frkz = this.getContainer().hasSkill("perk.crFurinkazan") || this.getContainer().hasSkill("perk.legend_freedom_of_movement");
 		this.m.FatigueCostMult = _properties.IsFleetfooted || frkz ? 0.5 : 1.0;
 
 		if (this.getContainer().getActor().getSkills().hasSkill("effects.goblin_grunt_potion") || frkz)


### PR DESCRIPTION
Change warrior's starting perk from forceful swing to bloody harvest.
Change minstrel's starting perk to minnesanger by default, since specialist skills reworked has been merged into legends.
Remove rotation from noble house starting bros, since they already get tactical maneuvers.

Fixes Furinkazan overwriting freedom of movement ap reductions.
Freedom of movement now effects audacious charge.
Updated furinkazan and freedom of movement perk strings to reflect that they don't stack.

Integrate pot's double grip fix (regular double grip effects now apply).